### PR TITLE
Added order_by functionality to QueryBuilder and QSet classes

### DIFF
--- a/supadantic/q_set.py
+++ b/supadantic/q_set.py
@@ -392,3 +392,15 @@ class QSet(Generic[_M]):
                 self._cache == getattr(obj, '_cache'),
             )
         )
+    
+    def order_by(self, *fields: str) -> 'QSet[_M]':
+        # Validate fields
+        for field in fields:
+            field_name = field.lstrip('-')
+            if field_name not in self._model_class.model_fields:
+                raise self.InvalidField(f'Invalid field {field_name}!')
+
+        # Set ordering in the query builder
+        self._query_builder.set_ordering(fields)
+
+        return self._copy()


### PR DESCRIPTION
This pull request introduces the order_by method to the QueryBuilder and QSet classes. The order_by method allows for easy sorting of query results based on specified fields. 