### PR TITLE
refresh_from_db

### DIFF
--- a/supadantic/models.py
+++ b/supadantic/models.py
@@ -154,6 +154,22 @@ class BaseSBModel(BaseModel, ABC, metaclass=ModelMetaclass):
 
         return cls._meta.db_client
 
+    def refresh_from_db(self: _M) -> None:
+        """
+        Reload this instance’s state from the database.
+
+        Raises:
+            DoesNotExist: if no row with this instance’s PK exists.
+            ValueError: if this instance has no primary key set.
+        """
+        if self.id is None:
+            raise ValueError(f"Cannot refresh {self.__class__.__name__} without an `id`")
+
+        fresh: _M = self.__class__.objects.get(id=self.id)
+
+        for name in self.__class__.model_fields.keys():
+            setattr(self, name, getattr(fresh, name))
+
     @classmethod
     def _get_table_name(cls) -> str:
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -48,6 +48,25 @@ class TestBaseSBModel:
     def test_objects(self, model_mock: type['ModelMock']):
         assert isinstance(model_mock.objects, QSet)
 
+    def test_refresh_from_db(self, model_mock: type['ModelMock']):
+        original = model_mock(
+            name='initial',
+            some_optional_list=['a', 'b'],
+            some_optional_tuple=('x', 'y'),
+        ).save()
+
+        model_mock.objects.filter(id=original.id).update(
+            name='updated',
+            some_optional_tuple=('z',),
+        )
+
+        original.refresh_from_db()
+
+        assert original.id == original.id
+        assert original.name == 'updated'
+        assert original.some_optional_list == ['a', 'b']
+        assert original.some_optional_tuple == ('z',)
+
 
 class TestBaseSBModelCustomSchema:
     def test_db_client_with_custom_schema(self, model_mock_custom_schema: type['ModelMock']):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,21 +51,26 @@ class TestBaseSBModel:
     def test_refresh_from_db(self, model_mock: type['ModelMock']):
         original = model_mock(
             name='initial',
-            some_optional_list=['a', 'b'],
-            some_optional_tuple=('x', 'y'),
+            some_optional_list=['old', 'data'],
+            some_optional_tuple=('old', 'data'),
         ).save()
 
         model_mock.objects.filter(id=original.id).update(
             name='updated',
-            some_optional_tuple=('z',),
+            some_optional_tuple=('updated', 'data'),
         )
+
+        assert original.id == original.id
+        assert original.name == 'initial'
+        assert original.some_optional_list == ['old', 'data']
+        assert original.some_optional_tuple == ('old', 'data')
 
         original.refresh_from_db()
 
         assert original.id == original.id
         assert original.name == 'updated'
-        assert original.some_optional_list == ['a', 'b']
-        assert original.some_optional_tuple == ('z',)
+        assert original.some_optional_list == ['old', 'data']
+        assert original.some_optional_tuple == ('updated', 'data')
 
 
 class TestBaseSBModelCustomSchema:


### PR DESCRIPTION
closes #90 

Tested on my local project : https://github.com/darya-shynkevich/comment_generator

The local project is a bit messy, sorry for that. yet the refresh_from_db seems to work. 

I also think it may be a good idea to contact the owners of the https://github.com/AtticusZeller/fastapi_supabase_template to integrate the library into it. WDYT? 